### PR TITLE
Create layer control panel with title and basic layer name

### DIFF
--- a/public/components/layer_control_panel.scss
+++ b/public/components/layer_control_panel.scss
@@ -1,0 +1,7 @@
+.leaflet-control-layer {
+  min-width: 15rem;
+
+  .leaflet-control-layer-title {
+    padding-left: 0.5rem;
+  }
+}

--- a/public/components/layer_control_panel.tsx
+++ b/public/components/layer_control_panel.tsx
@@ -1,31 +1,4 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */

--- a/public/components/layer_control_panel.tsx
+++ b/public/components/layer_control_panel.tsx
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
+import './layer_control_panel.scss';
+
+function LayerControlPanel() {
+  return (
+    <I18nProvider>
+      <EuiPanel paddingSize="s" className='leaflet-control leaflet-control-layer'>
+        <EuiTitle size="xs" className='leaflet-control-layer-title'>
+          <h2>
+            <FormattedMessage
+              id="mapsExplorerDashboards.opensearchDashboardsMap.leaflet.layerControlTitle"
+              defaultMessage="Layers"
+            />
+          </h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <div>Roadmap </div>
+        <EuiSpacer size="s" />
+      </EuiPanel>
+    </I18nProvider>
+  );
+}
+
+export { LayerControlPanel };

--- a/public/map/base_maps_visualization.js
+++ b/public/map/base_maps_visualization.js
@@ -113,6 +113,7 @@ export function BaseMapsVisualizationProvider() {
 
       this._opensearchDashboardsMap.addLegendControl();
       this._opensearchDashboardsMap.addFitControl();
+      this._opensearchDashboardsMap.addLayerControl();
       this._opensearchDashboardsMap.persistUiStateForVisualization(this.vis);
 
       this._opensearchDashboardsMap.on('baseLayer:loaded', () => {

--- a/public/map/opensearch_dashboards_map.js
+++ b/public/map/opensearch_dashboards_map.js
@@ -31,6 +31,8 @@
  */
 
 import { EventEmitter } from 'events';
+import ReactDOM from 'react-dom'
+import React from 'react'
 import {
   createZoomWarningMsg,
   createRegionBlockedWarning,
@@ -43,6 +45,30 @@ import { i18n } from '@osd/i18n';
 import { ORIGIN } from '../common/constants/origin';
 import { getToasts } from '../maps_explorer_dashboards_services';
 import { L } from '../leaflet';
+import { LayerControlPanel } from '../components/layer_control_panel';
+
+function makeLayerControl(layerContainer, opensearchDashboardsMap) {
+  // eslint-disable-next-line no-undef
+  const LayerControl = L.Control.extend({
+    options: {
+      position: 'topright',
+    },
+    initialize: function (layerContainer, opensearchDashboardsMap) {
+      this._layerContainer = layerContainer;
+      this._opensearchDashboardsMap = opensearchDashboardsMap;
+    },
+    onAdd: function () {
+      console.log("layerControl onAdd");
+      ReactDOM.render(<LayerControlPanel />, this._layerContainer)
+      return this._layerContainer;
+    },
+    onRemove: function () {
+      console.log("layerControl onRemove");
+    },
+  });
+
+  return new LayerControl(layerContainer, opensearchDashboardsMap);
+}
 
 function makeFitControl(fitContainer, opensearchDashboardsMap) {
   // eslint-disable-next-line no-undef
@@ -129,6 +155,7 @@ export class OpenSearchDashboardsMap extends EventEmitter {
     this._baseLayerIsDesaturated = true;
 
     this._leafletDrawControl = null;
+    this._leafletLayerControl = null;
     this._leafletFitControl = null;
     this._leafletLegendControl = null;
     this._legendPosition = 'topright';
@@ -499,6 +526,17 @@ export class OpenSearchDashboardsMap extends EventEmitter {
     // eslint-disable-next-line no-undef
     this._leafletDrawControl = new L.Control.Draw(drawOptions);
     this._leafletMap.addControl(this._leafletDrawControl);
+  }
+
+  addLayerControl() {
+    if (this._leafletLayerControl || !this._leafletMap) {
+      return;
+    }
+
+    // eslint-disable-next-line no-undef
+    const layerContainer = L.DomUtil.create('div');
+    this._leafletLayerControl = makeLayerControl(layerContainer, this);
+    this._leafletMap.addControl(this._leafletLayerControl);
   }
 
   addFitControl() {


### PR DESCRIPTION
### Problem:
- Launch the map without Layer panel.

### Why important:
- Navigate users to the layer panel.
- Show the basic layer name.

### Description:
- Create LayerControlPanel() to format the new component
- Create makeLayerControl() to render the new component
 
### Issues Resolved:
#9 

### Current Image:
<img width="2018" alt="Screen Shot 2022-06-07 at 12 09 10 PM" src="https://user-images.githubusercontent.com/47327467/172462957-efc9bb6c-cd57-4118-b2c3-653c11cab0bf.png">


 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
