### PR TITLE
Treat TMS layer as a regular layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ dist
 # TernJS port file
 .tern-port
 target
+public/.DS_Store

--- a/public/components/layer_control_panel.tsx
+++ b/public/components/layer_control_panel.tsx
@@ -8,7 +8,32 @@ import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
 import './layer_control_panel.scss';
 
-function LayerControlPanel() {
+interface LayerMetadata {
+  id: string;
+  name: string;
+}
+
+interface LayerControlPanelProps {
+  layers: LayerMetadata[],
+}
+
+/**
+ * Get layer's name or layer's ID to display
+ * Otherwise, display "unnamed Layer" as placeholder
+ * @param layerMetadata 
+ * @returns 
+ */
+function getLayerDisplayName(layerMetadata: LayerMetadata) {
+  if (layerMetadata.name) {
+    return layerMetadata.name;
+  } else if (layerMetadata.id) {
+    return layerMetadata.id;
+  } else {
+    return "Unnamed Layer";
+  }
+}
+
+function LayerControlPanel(props: LayerControlPanelProps) {
   return (
     <I18nProvider>
       <EuiPanel paddingSize="s" className='leaflet-control leaflet-control-layer'>
@@ -21,11 +46,34 @@ function LayerControlPanel() {
           </h2>
         </EuiTitle>
         <EuiSpacer size="s" />
-        <div>Roadmap </div>
-        <EuiSpacer size="s" />
+        {props.layers.map(
+          (layerMetadata, idx) => {
+            return (
+              <LayerControlPanelItem key={"layer" + idx} metadata={layerMetadata} />
+            )
+          })}
       </EuiPanel>
     </I18nProvider>
   );
 }
 
-export { LayerControlPanel };
+interface LayerControlPanelItemProps {
+  metadata: LayerMetadata,
+}
+
+/**
+ * Create new layer item
+ * Could add future (edit/delete/hide)buttons
+ * @param props 
+ * @returns 
+ */
+function LayerControlPanelItem(props: LayerControlPanelItemProps) {
+  return (
+    <>
+      <span>{getLayerDisplayName(props.metadata)}</span>
+      <EuiSpacer size="s" />
+    </>
+  )
+}
+
+export { LayerMetadata, LayerControlPanel };

--- a/public/map/base_maps_visualization.js
+++ b/public/map/base_maps_visualization.js
@@ -142,7 +142,7 @@ export function BaseMapsVisualizationProvider() {
     }
 
     /**
-     * Create tmeLayer
+     * Create tmsLayer
      * @param {*} tmsLayerOptions 
      */
     async _setTmsLayer(tmsLayerOptions) {
@@ -166,9 +166,9 @@ export function BaseMapsVisualizationProvider() {
       const options = { ...tmsLayerOptions, showZoomMessage, ...meta };
       // delete options.id;
       delete options.subdomains;
-      // create a new TmsLayer and add it to layers
-      const { TmsLayer } = await import('./layer/tms_layer/tms_layer');
-      const tmsLayer = new TmsLayer(options, this._opensearchDashboardsMap, this.L);
+      // create a new TMSLayer and add it to layers
+      const { TMSLayer } = await import('./layer/tms_layer/tms_layer');
+      const tmsLayer = new TMSLayer(options, this._opensearchDashboardsMap, this.L);
       this._opensearchDashboardsMap.addLayer(tmsLayer);
     }
 

--- a/public/map/layer/opensearch_dashboards_map_layer.ts
+++ b/public/map/layer/opensearch_dashboards_map_layer.ts
@@ -33,6 +33,10 @@
 import { EventEmitter } from 'events';
 
 export class OpenSearchDashboardsMapLayer extends EventEmitter {
+
+  _leafletLayer: any;
+  _attribution: any;
+  
   constructor() {
     super();
     this._leafletLayer = null;
@@ -42,11 +46,11 @@ export class OpenSearchDashboardsMapLayer extends EventEmitter {
     return this._leafletLayer.getBounds();
   }
 
-  addToLeafletMap(leafletMap) {
+  addToLeafletMap(leafletMap: any) {
     this._leafletLayer.addTo(leafletMap);
   }
 
-  removeFromLeafletMap(leafletMap) {
+  removeFromLeafletMap(leafletMap: any) {
     leafletMap.removeLayer(this._leafletLayer);
   }
 
@@ -59,4 +63,11 @@ export class OpenSearchDashboardsMapLayer extends EventEmitter {
   getAttributions() {
     return this._attribution;
   }
+
+  /**
+   * Update the layer's desaturated status
+   * @param isDesaturated 
+   * @returns 
+   */
+  setDesaturate(isDesaturated: boolean) {}
 }

--- a/public/map/layer/tms_layer/tms_layer.ts
+++ b/public/map/layer/tms_layer/tms_layer.ts
@@ -1,0 +1,88 @@
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { OpenSearchDashboardsMapLayer } from "../../..";
+import {
+    createRegionBlockedWarning,
+    removeRegionBlockedWarning
+} from '../../map_messages';
+import { ORIGIN } from '../../../common/constants/origin';
+
+/**
+ * Construct TmsLayer
+ */
+export class TmsLayer extends OpenSearchDashboardsMapLayer {
+    _options;
+    _opensearchDashboardsMap;
+    _leaflet;
+    _isDesaturated;
+
+    constructor(
+        options: any,
+        opensearchDashboardsMap: any,
+        leaflet: any
+    ) {
+        super();
+        this._options = options;
+        this._opensearchDashboardsMap = opensearchDashboardsMap;
+        this._leaflet = leaflet;
+        this._isDesaturated = true;
+        this._leafletLayer = this._createTmsLeafletLayer();
+    }
+
+    /**
+     * Create a new tmsLayer
+     * @returns leafletLayer
+     */
+    _createTmsLeafletLayer() {
+        let leafletLayer = this._leaflet.tileLayer(this._options.url, {
+            minZoom: this._options.minZoom,
+            maxZoom: this._options.maxZoom,
+            subdomains: this._options.subdomains || [],
+        });
+
+        if (leafletLayer) {
+            leafletLayer.on("tileload", () => this._updateDesaturation());
+            leafletLayer.on('tileerror', () => {
+                if (this._options.showRegionBlcokedWarning) {
+                    createRegionBlockedWarning();
+                }
+            });
+
+            if (this._options.showZoomMessage) {
+                leafletLayer.on('add', () => {
+                    this._opensearchDashboardsMap._addMaxZoomMessage(leafletLayer)
+                });
+            }
+        }
+        return leafletLayer;
+    }
+
+    _updateDesaturation() {
+        removeRegionBlockedWarning();
+        const tiles = $('img.leaflet-tile-loaded');
+        // Don't apply client-side styling to EMS basemaps
+        if (this._options.origin === ORIGIN.EMS) {
+            tiles.addClass('filters-off');
+        } else if (this._isDesaturated) {
+            tiles.removeClass('filters-off');
+        }
+        else if (!this._isDesaturated) {
+            tiles.addClass('fileters-off');
+        }
+    }
+
+    setDesaturate(isDesaturated: boolean) {
+        if (isDesaturated === this._isDesaturated) {
+            return;
+        }
+        this._isDesaturated = isDesaturated;
+        this._updateDesaturation();
+        if (this._leafletLayer) {
+            this._leafletLayer.redraw();
+        }
+    }
+
+}

--- a/public/map/layer/tms_layer/tms_layer.ts
+++ b/public/map/layer/tms_layer/tms_layer.ts
@@ -13,7 +13,7 @@ import { ORIGIN } from '../../../common/constants/origin';
 /**
  * Construct TmsLayer
  */
-export class TmsLayer extends OpenSearchDashboardsMapLayer {
+export class TMSLayer extends OpenSearchDashboardsMapLayer {
     _options;
     _opensearchDashboardsMap;
     _leaflet;

--- a/public/maps_explorer_dashboards_visualization.js
+++ b/public/maps_explorer_dashboards_visualization.js
@@ -212,7 +212,7 @@ export const createVisualization = (dependencies) => {
     async _updateParams() {
       await super._updateParams();
 
-      this._opensearchDashboardsMap.setDesaturateBaseLayer(this._params.isDesaturated);
+      this._opensearchDashboardsMap.setDesaturate(this._params.isDesaturated);
 
       //avoid recreating the leaflet layer when there are option-changes that do not effect the representation
       //e.g. tooltip-visibility, legend position, basemap-desaturation, ...


### PR DESCRIPTION
### Problem:
- The current OpenSearchDashboardsMap does not allow users to add Tms layer as many as they want

### Description:
- Remove leafletBaseLayer from OpenSearchDashboardsMap
- Create TmsLayer as a OpenSearchDashboardsMapLayer, which can be add to OpenSearchDashboardsMap,_layers
- Remove WMS layer from OpenSearchDashboardsMap, could be added in the future if needed
- Add all rendered layers' name or ID as a list into LayerControlPanel

### Image:

 
<img width="1339" alt="Screen Shot 2022-06-13 at 3 09 37 PM" src="https://user-images.githubusercontent.com/47327467/173453501-07af5147-0697-4d77-91c6-5dab84b248eb.png">

### Issues Resolved
#9 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
